### PR TITLE
Fix CParamUtils being non-functional on Cheat Engine 7.6

### DIFF
--- a/table_files/include/tga/mem_diff_stack.h
+++ b/table_files/include/tga/mem_diff_stack.h
@@ -25,51 +25,51 @@ void memxor_simd(void* dest, void* src, size_t len);
 void memor_simd(void* dest, void* src, size_t len);
 void memandn_simd(void* dest, void* src, size_t len);
 void memand_simd(void* dest, void* src, size_t len);
-__asm__("
+__asm__(
 
-memxor_simd:
-	xorq %rax, %rax
-loop_xor_simd:
-	movaps (%rcx, %rax), %xmm0
-	pxor (%rdx, %rax), %xmm0
-	movaps %xmm0, (%rcx, %rax)
-	addq $0x10, %rax
-	cmpq %rax, %r8
-	ja loop_xor_simd
-	ret
+"memxor_simd:\n\t"
+	"xorq %rax, %rax\n"
+"loop_xor_simd:\n\t"
+	"movaps (%rcx, %rax), %xmm0\n\t"
+	"pxor (%rdx, %rax), %xmm0\n\t"
+	"movaps %xmm0, (%rcx, %rax)\n\t"
+	"addq $0x10, %rax\n\t"
+	"cmpq %rax, %r8\n\t"
+	"ja loop_xor_simd\n\t"
+	"ret\n"
 
-memor_simd:
-	xorq %rax, %rax
-loop_or_simd:
-	movaps (%rcx, %rax), %xmm0
-	por (%rdx, %rax), %xmm0
-	movaps %xmm0, (%rcx, %rax)
-	addq $0x10, %rax
-	cmpq %rax, %r8
-	ja loop_or_simd
-	ret
+"memor_simd:\n\t"
+	"xorq %rax, %rax\n"
+"loop_or_simd:\n\t"
+	"movaps (%rcx, %rax), %xmm0\n\t"
+	"por (%rdx, %rax), %xmm0\n\t"
+	"movaps %xmm0, (%rcx, %rax)\n\t"
+	"addq $0x10, %rax\n\t"
+	"cmpq %rax, %r8\n\t"
+	"ja loop_or_simd\n\t"
+	"ret\n"
 
-memandn_simd:
-	xorq %rax, %rax
-loop_andn_simd:
-	movaps (%rcx, %rax), %xmm0
-	pandn (%rdx, %rax), %xmm0
-	movaps %xmm0, (%rcx, %rax)
-	addq $0x10, %rax
-	cmpq %rax, %r8
-	ja loop_andn_simd
-	ret
+"memandn_simd:\n\t"
+	"xorq %rax, %rax\n"
+"loop_andn_simd:\n\t"
+	"movaps (%rcx, %rax), %xmm0\n\t"
+	"pandn (%rdx, %rax), %xmm0\n\t"
+	"movaps %xmm0, (%rcx, %rax)\n\t"
+	"addq $0x10, %rax\n\t"
+	"cmpq %rax, %r8\n\t"
+	"ja loop_andn_simd\n\t"
+	"ret\n"
 
-memand_simd:
-	xorq %rax, %rax
-loop_and_simd:
-	movaps (%rcx, %rax), %xmm0
-	pand (%rdx, %rax), %xmm0
-	movaps %xmm0, (%rcx, %rax)
-	addq $0x10, %rax
-	cmpq %rax, %r8
-	ja loop_and_simd
-	ret"
+"memand_simd:\n\t"
+	"xorq %rax, %rax\n"
+"loop_and_simd:\n\t"
+	"movaps (%rcx, %rax), %xmm0\n\t"
+	"pand (%rdx, %rax), %xmm0\n\t"
+	"movaps %xmm0, (%rcx, %rax)\n\t"
+	"addq $0x10, %rax\n\t"
+	"cmpq %rax, %r8\n\t"
+	"ja loop_and_simd\n\t"
+	"ret"
 );
 
 #define align16(n) (((n) + 0xF) & ~(uint64_t)0xF)

--- a/table_files/include/tga/safe_ptr_read.h
+++ b/table_files/include/tga/safe_ptr_read.h
@@ -16,16 +16,15 @@ PVOID _BAD_PTR_VEH_HANDLE = NULL;
 bool _safe_ptr_do_read(void* ptr, uint64_t* out_value);
 void _safe_ptr_exception_point();
 void _safe_ptr_do_read_end();
-__asm__("
-    _safe_ptr_do_read:
-        xorb %al, %al
-        movq (%rcx), %r8
-    _safe_ptr_exception_point:
-        movq %r8, (%rdx)
-        movb $1, %al
-    _safe_ptr_do_read_end:
-        ret
-    "
+__asm__(
+    "_safe_ptr_do_read:\n\t"
+        "xorb %al, %al\n\t"
+        "movq (%rcx), %r8\n"
+    "_safe_ptr_exception_point:\n\t"
+        "movq %r8, (%rdx)\n\t"
+        "movb $1, %al\n"
+    "_safe_ptr_do_read_end:\n\t"
+        "ret"
 );
 
 LONG _safe_ptr_veh_handler(uint8_t* ExceptionInfo)


### PR DESCRIPTION
This is the same fix as https://github.com/The-Grand-Archives/Elden-Ring-CT-TGA/pull/141 to fix CParamUtils breakage on Cheat Engine 7.6.